### PR TITLE
Allow OAP to pass API keys to the agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ ANTHROPIC_API_KEY=""
 SUPABASE_URL=""
 # Ensure this is your Supabase Service Role key
 SUPABASE_KEY=""
+
+# Should be set to true for Open Agent Platform deployments. OAP will pass the model API key through the config.
+GET_API_KEYS_FROM_CONFIG=true

--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,5 @@ SUPABASE_URL=""
 # Ensure this is your Supabase Service Role key
 SUPABASE_KEY=""
 
-# Should be set to true for Open Agent Platform deployments. OAP will pass the model API key through the config.
+# Should be set to "true" for Open Agent Platform deployments. OAP will pass the model API key through the config.
 GET_API_KEYS_FROM_CONFIG=true

--- a/tools_agent/agent.py
+++ b/tools_agent/agent.py
@@ -148,16 +148,16 @@ def get_api_key_for_model(model_name: str, config: RunnableConfig):
             return api_keys.get("OPENAI_API_KEY")
         elif model_name.startswith("anthropic:"):
             return api_keys.get("ANTHROPIC_API_KEY")
-        elif model_name.startswith("gemini:"):
-            return api_keys.get("GEMINI_API_KEY")
+        elif model_name.startswith("google"):
+            return api_keys.get("GOOGLE_API_KEY")
         return None
     else:
         if model_name.startswith("openai:"): 
             return os.getenv("OPENAI_API_KEY")
         elif model_name.startswith("anthropic:"):
             return os.getenv("ANTHROPIC_API_KEY")
-        elif model_name.startswith("gemini:"):
-            return os.getenv("GEMINI_API_KEY")
+        elif model_name.startswith("google"):
+            return os.getenv("GOOGLE_API_KEY")
         return None
 
 

--- a/tools_agent/agent.py
+++ b/tools_agent/agent.py
@@ -138,9 +138,9 @@ class GraphConfigPydantic(BaseModel):
 
 
 def get_api_key_for_model(model_name: str, config: RunnableConfig):
-    should_get_from_config = os.getenv("GET_API_KEYS_FROM_CONFIG", False)
+    should_get_from_config = os.getenv("GET_API_KEYS_FROM_CONFIG", "false")
     model_name = model_name.lower()
-    if should_get_from_config:
+    if should_get_from_config.lower() == "true":
         api_keys = config.get("configurable", {}).get("apiKeys", {})
         if not api_keys:
             return None

--- a/tools_agent/agent.py
+++ b/tools_agent/agent.py
@@ -243,7 +243,6 @@ async def graph(config: RunnableConfig):
         max_tokens=cfg.max_tokens,
         api_key=get_api_key_for_model(cfg.model_name, config) or "No token found",
     )
-    print(f"API KEY:",  get_api_key_for_model(cfg.model_name, config))
 
     return create_react_agent(
         prompt=cfg.system_prompt + UNEDITABLE_SYSTEM_PROMPT,


### PR DESCRIPTION
Configuring `GET_API_KEYS_FROM_CONFIG=true` fetches the relevant model API key from the model config as opposed to from the environment.

This is important for OAP, where users can configure their API keys in the UI, and these will be passed to the agent at runtime.